### PR TITLE
Removed uneccesary nginx build that caused issues with the frontend container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,4 @@
 services:
-    nginx:
-        container_name: nginx
-        image: nginx:alpine
-        ports:
-            - 80:80
-        volumes:
-            - type: bind
-              source: ./nginx/nginx.conf
-              target: /etc/nginx/nginx.conf
-
     backend:
         container_name: "pet-clinic-backend"
         image: costi0/pet-clinic-backend
@@ -22,3 +12,5 @@ services:
         container_name: "pet-clinic-frontend"
         image: costi0/pet-clinic-frontend
         build: spring-petclinic-angular
+        ports:
+            - 8080:8080


### PR DESCRIPTION
It seems like I was doing double work which resulted in clashing between the frontend and the nginx containers.
I was already taking care of the nginx in the frontend container, however, in docker compose I was also building up an nginx container and redo-ing the same steps. This resulted in a clash and I was keep getting 404 when trying to access the website.
However this has now been fixed by removing the double work made by the nginx image in docker compose.

This also means that when running docker compose, now the backend and frontend work in harmony and well together compared with before where it could only be possible to execute them independently.

Please accept the pull request.